### PR TITLE
[puppet/python] Fix virtualenv version checking syntax

### DIFF
--- a/manifests/virtualenv.pp
+++ b/manifests/virtualenv.pp
@@ -134,7 +134,7 @@ define python::virtualenv (
     $pip_cmd   = "${python::exec_prefix}${venv_dir}/bin/pip"
     $pip_flags = "${pypi_index} ${proxy_flag} ${pip_args}"
 
-    if $version =~ /3.*/ { #lint:ignore:only_variable_string
+    if "${version}" =~ /3.*/ { #lint:ignore:only_variable_string
       $pip_install_cmd = "true ${proxy_command} && ${virtualenv_cmd} ${system_pkgs_flag} -p ${python} ${venv_dir} && ${pip_cmd} --log ${venv_dir}/pip.log install ${pip_flags} --upgrade pip && ${pip_cmd} install ${pip_flags} --upgrade ${distribute_pkg}"
     } else {
       $py2_distribute_pkg = "'setuptools==44.1.0' 'distribute==0.7.3' 'wheel==0.36.2'"

--- a/manifests/virtualenv.pp
+++ b/manifests/virtualenv.pp
@@ -53,8 +53,6 @@ define python::virtualenv (
 ) {
   include ::python
 
-  $python_version = getparam(Class['python'], 'version')
-
   $python_provider = getparam(Class['python'], 'provider')
   $anaconda_path = getparam(Class['python'], 'anaconda_install_path')
 
@@ -136,7 +134,7 @@ define python::virtualenv (
     $pip_cmd   = "${python::exec_prefix}${venv_dir}/bin/pip"
     $pip_flags = "${pypi_index} ${proxy_flag} ${pip_args}"
 
-    if "${python_version}" =~ /^python3/ { #lint:ignore:only_variable_string
+    if $version =~ /3.*/ { #lint:ignore:only_variable_string
       $pip_install_cmd = "true ${proxy_command} && ${virtualenv_cmd} ${system_pkgs_flag} -p ${python} ${venv_dir} && ${pip_cmd} --log ${venv_dir}/pip.log install ${pip_flags} --upgrade pip && ${pip_cmd} install ${pip_flags} --upgrade ${distribute_pkg}"
     } else {
       $py2_distribute_pkg = "'setuptools==44.1.0' 'distribute==0.7.3' 'wheel==0.36.2'"


### PR DESCRIPTION
Created a simple `virtualenv` resource
```
  python::virtualenv { '/var/venv/test':
    version    => 3,
  }
```

Confirmed that puppet would run successfully and correctly build the virtual environment. Also tested with version `2` and version `3.6` to ensure the behaviour also looks correct. 